### PR TITLE
Add React math keyboard demo

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,11 @@
+# Math Input Demo
+
+This prototype demonstrates a React component using [mathlive](https://github.com/arnog/mathlive) to render an editable math field with a minimal custom keyboard for fractions, roots and exponents. The component outputs both LaTeX and MathML.
+
+## Usage
+
+```
+npm start
+```
+
+Then open the served `demo/index.html` in a browser. Typing in the field or using the buttons updates the LaTeX and MathML shown below the keyboard.

--- a/demo/index.html
+++ b/demo/index.html
@@ -1,0 +1,21 @@
+<!DOCTYPE html>
+<html>
+  <head>
+    <meta charset="UTF-8" />
+    <title>Math Input Demo</title>
+    <script crossorigin src="https://unpkg.com/react@18/umd/react.development.js"></script>
+    <script crossorigin src="https://unpkg.com/react-dom@18/umd/react-dom.development.js"></script>
+    <script src="https://unpkg.com/mathlive/dist/mathlive.min.js"></script>
+    <style>
+      .keyboard button { margin: 0 4px; }
+    </style>
+  </head>
+  <body>
+    <div id="root"></div>
+    <script type="module">
+      import { MathInput } from '../src/MathInput.js';
+      const root = ReactDOM.createRoot(document.getElementById('root'));
+      root.render(React.createElement(MathInput));
+    </script>
+  </body>
+</html>

--- a/package.json
+++ b/package.json
@@ -1,0 +1,9 @@
+{
+  "name": "math-input-demo",
+  "version": "1.0.0",
+  "private": true,
+  "scripts": {
+    "start": "npx serve demo",
+    "test": "echo 'No tests'"
+  }
+}

--- a/src/MathInput.js
+++ b/src/MathInput.js
@@ -1,0 +1,48 @@
+export function MathInput() {
+  const fieldRef = React.useRef(null);
+  const [latex, setLatex] = React.useState('');
+  const [mathml, setMathml] = React.useState('');
+
+  React.useEffect(() => {
+    const mf = new MathLive.MathfieldElement();
+    fieldRef.current.appendChild(mf);
+    mf.addEventListener('input', () => {
+      setLatex(mf.getValue('latex'));
+      setMathml(mf.getValue('mathML'));
+    });
+    fieldRef.current.mathfield = mf;
+  }, []);
+
+  const insert = (code) => {
+    const mf = fieldRef.current.mathfield;
+    mf.insert(code);
+    mf.focus();
+  };
+
+  return React.createElement(
+    'div',
+    null,
+    React.createElement('div', { ref: fieldRef }),
+    React.createElement(
+      'div',
+      { className: 'keyboard' },
+        React.createElement(
+          'button',
+          { onClick: () => insert('\\frac{}{}') },
+          'Fraction'
+        ),
+        React.createElement(
+          'button',
+          { onClick: () => insert('\\sqrt{}') },
+          'Root'
+        ),
+      React.createElement(
+        'button',
+        { onClick: () => insert('^{}') },
+        'Exponent'
+      )
+    ),
+    React.createElement('pre', null, `LaTeX: ${latex}`),
+    React.createElement('pre', null, `MathML: ${mathml}`)
+  );
+}


### PR DESCRIPTION
## Summary
- add MathInput React component with custom buttons for fractions, roots and exponents
- include demo page loading React and MathLive from CDN
- document usage

## Testing
- `npm test`


------
https://chatgpt.com/codex/tasks/task_e_68a6e1e8eb4c833381a57ca50dd5044c